### PR TITLE
Disable sRGB framebuffer for OpenGL and Vulkan, 

### DIFF
--- a/chapter01/01_opengl_assimp/opengl/Framebuffer.cpp
+++ b/chapter01/01_opengl_assimp/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter01/01_opengl_assimp/opengl/OGLRenderer.cpp
+++ b/chapter01/01_opengl_assimp/opengl/OGLRenderer.cpp
@@ -73,6 +73,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init */
@@ -376,7 +380,6 @@ bool OGLRenderer::draw(float deltaTime) {
   glClearColor(0.25f, 0.25f, 0.25f, 1.0f);
   glClearDepth(1.0f);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-  glEnable(GL_FRAMEBUFFER_SRGB);
 
   mMatrixGenerateTimer.start();
   mCamera.updateCamera(mRenderData, deltaTime);
@@ -448,10 +451,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   mUIGenerateTimer.start();
   mUserInterface.hideMouse(mMouseLock);

--- a/chapter01/01_opengl_assimp/shader/assimp.frag
+++ b/chapter01/01_opengl_assimp/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter01/01_opengl_assimp/shader/assimp_skinning.frag
+++ b/chapter01/01_opengl_assimp/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter01/02_vulkan_assimp/shader/assimp.frag
+++ b/chapter01/02_vulkan_assimp/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter01/02_vulkan_assimp/shader/assimp_skinning.frag
+++ b/chapter01/02_vulkan_assimp/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter01/02_vulkan_assimp/vulkan/VkRenderer.cpp
+++ b/chapter01/02_vulkan_assimp/vulkan/VkRenderer.cpp
@@ -472,10 +472,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter02/01_opengl_computeshader/opengl/Framebuffer.cpp
+++ b/chapter02/01_opengl_computeshader/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height,  0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter02/01_opengl_computeshader/opengl/OGLRenderer.cpp
+++ b/chapter02/01_opengl_computeshader/opengl/OGLRenderer.cpp
@@ -386,7 +386,9 @@ bool OGLRenderer::draw(float deltaTime) {
   glClearColor(0.25f, 0.25f, 0.25f, 1.0f);
   glClearDepth(1.0f);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-  glEnable(GL_FRAMEBUFFER_SRGB);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
 
   mMatrixGenerateTimer.start();
   mCamera.updateCamera(mRenderData, deltaTime);
@@ -496,10 +498,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   mUIGenerateTimer.start();
   mUserInterface.hideMouse(mMouseLock);

--- a/chapter02/01_opengl_computeshader/shader/assimp.frag
+++ b/chapter02/01_opengl_computeshader/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter02/01_opengl_computeshader/shader/assimp_skinning.frag
+++ b/chapter02/01_opengl_computeshader/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter02/02_vulkan_computeshader/shader/assimp.frag
+++ b/chapter02/02_vulkan_computeshader/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter02/02_vulkan_computeshader/shader/assimp_skinning.frag
+++ b/chapter02/02_vulkan_computeshader/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter02/02_vulkan_computeshader/vulkan/VkRenderer.cpp
+++ b/chapter02/02_vulkan_computeshader/vulkan/VkRenderer.cpp
@@ -743,10 +743,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter03/01_opengl_selection/opengl/Framebuffer.cpp
+++ b/chapter03/01_opengl_selection/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter03/01_opengl_selection/opengl/OGLRenderer.cpp
+++ b/chapter03/01_opengl_selection/opengl/OGLRenderer.cpp
@@ -105,6 +105,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init */
@@ -814,10 +818,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   mUIGenerateTimer.start();
   mUserInterface.hideMouse(mMouseLock);

--- a/chapter03/01_opengl_selection/shader/assimp.frag
+++ b/chapter03/01_opengl_selection/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter03/01_opengl_selection/shader/assimp_selection.frag
+++ b/chapter03/01_opengl_selection/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter03/01_opengl_selection/shader/assimp_skinning.frag
+++ b/chapter03/01_opengl_selection/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter03/01_opengl_selection/shader/assimp_skinning_selection.frag
+++ b/chapter03/01_opengl_selection/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter03/01_opengl_selection/shader/line.frag
+++ b/chapter03/01_opengl_selection/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter03/02_vulkan_selection/shader/assimp.frag
+++ b/chapter03/02_vulkan_selection/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter03/02_vulkan_selection/shader/assimp_selection.frag
+++ b/chapter03/02_vulkan_selection/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter03/02_vulkan_selection/shader/assimp_skinning.frag
+++ b/chapter03/02_vulkan_selection/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter03/02_vulkan_selection/shader/assimp_skinning_selection.frag
+++ b/chapter03/02_vulkan_selection/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter03/02_vulkan_selection/shader/line.frag
+++ b/chapter03/02_vulkan_selection/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter03/02_vulkan_selection/vulkan/VkRenderer.cpp
+++ b/chapter03/02_vulkan_selection/vulkan/VkRenderer.cpp
@@ -1158,10 +1158,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter04/01_opengl_edit_view_mode/opengl/Framebuffer.cpp
+++ b/chapter04/01_opengl_edit_view_mode/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter04/01_opengl_edit_view_mode/opengl/OGLRenderer.cpp
+++ b/chapter04/01_opengl_edit_view_mode/opengl/OGLRenderer.cpp
@@ -110,6 +110,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init */
@@ -924,10 +928,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   if (mRenderData.rdApplicationMode == appMode::edit) {
     mUIGenerateTimer.start();

--- a/chapter04/01_opengl_edit_view_mode/shader/assimp.frag
+++ b/chapter04/01_opengl_edit_view_mode/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter04/01_opengl_edit_view_mode/shader/assimp_selection.frag
+++ b/chapter04/01_opengl_edit_view_mode/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter04/01_opengl_edit_view_mode/shader/assimp_skinning.frag
+++ b/chapter04/01_opengl_edit_view_mode/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter04/01_opengl_edit_view_mode/shader/assimp_skinning_selection.frag
+++ b/chapter04/01_opengl_edit_view_mode/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter04/01_opengl_edit_view_mode/shader/line.frag
+++ b/chapter04/01_opengl_edit_view_mode/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter04/02_vulkan_edit_view_mode/shader/assimp.frag
+++ b/chapter04/02_vulkan_edit_view_mode/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter04/02_vulkan_edit_view_mode/shader/assimp_selection.frag
+++ b/chapter04/02_vulkan_edit_view_mode/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter04/02_vulkan_edit_view_mode/shader/assimp_skinning.frag
+++ b/chapter04/02_vulkan_edit_view_mode/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter04/02_vulkan_edit_view_mode/shader/assimp_skinning_selection.frag
+++ b/chapter04/02_vulkan_edit_view_mode/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter04/02_vulkan_edit_view_mode/shader/line.frag
+++ b/chapter04/02_vulkan_edit_view_mode/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter04/02_vulkan_edit_view_mode/vulkan/VkRenderer.cpp
+++ b/chapter04/02_vulkan_edit_view_mode/vulkan/VkRenderer.cpp
@@ -1199,10 +1199,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter05/01_opengl_load_save/opengl/Framebuffer.cpp
+++ b/chapter05/01_opengl_load_save/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter05/01_opengl_load_save/opengl/OGLRenderer.cpp
+++ b/chapter05/01_opengl_load_save/opengl/OGLRenderer.cpp
@@ -111,6 +111,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init */
@@ -1273,10 +1277,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   if (mRenderData.rdApplicationMode == appMode::edit) {
     mUIGenerateTimer.start();

--- a/chapter05/01_opengl_load_save/shader/assimp.frag
+++ b/chapter05/01_opengl_load_save/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter05/01_opengl_load_save/shader/assimp_selection.frag
+++ b/chapter05/01_opengl_load_save/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter05/01_opengl_load_save/shader/assimp_skinning.frag
+++ b/chapter05/01_opengl_load_save/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter05/01_opengl_load_save/shader/assimp_skinning_selection.frag
+++ b/chapter05/01_opengl_load_save/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter05/01_opengl_load_save/shader/line.frag
+++ b/chapter05/01_opengl_load_save/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter05/02_vulkan_load_save/shader/assimp.frag
+++ b/chapter05/02_vulkan_load_save/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter05/02_vulkan_load_save/shader/assimp_selection.frag
+++ b/chapter05/02_vulkan_load_save/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter05/02_vulkan_load_save/shader/assimp_skinning.frag
+++ b/chapter05/02_vulkan_load_save/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter05/02_vulkan_load_save/shader/assimp_skinning_selection.frag
+++ b/chapter05/02_vulkan_load_save/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter05/02_vulkan_load_save/shader/line.frag
+++ b/chapter05/02_vulkan_load_save/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter05/02_vulkan_load_save/vulkan/VkRenderer.cpp
+++ b/chapter05/02_vulkan_load_save/vulkan/VkRenderer.cpp
@@ -1373,10 +1373,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter06/01_opengl_cameras/opengl/Framebuffer.cpp
+++ b/chapter06/01_opengl_cameras/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter06/01_opengl_cameras/opengl/OGLRenderer.cpp
+++ b/chapter06/01_opengl_cameras/opengl/OGLRenderer.cpp
@@ -111,6 +111,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -1615,10 +1619,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter06/01_opengl_cameras/shader/assimp.frag
+++ b/chapter06/01_opengl_cameras/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter06/01_opengl_cameras/shader/assimp_selection.frag
+++ b/chapter06/01_opengl_cameras/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter06/01_opengl_cameras/shader/assimp_skinning.frag
+++ b/chapter06/01_opengl_cameras/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter06/01_opengl_cameras/shader/assimp_skinning_selection.frag
+++ b/chapter06/01_opengl_cameras/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter06/01_opengl_cameras/shader/line.frag
+++ b/chapter06/01_opengl_cameras/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter06/02_vulkan_cameras/shader/assimp.frag
+++ b/chapter06/02_vulkan_cameras/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter06/02_vulkan_cameras/shader/assimp_selection.frag
+++ b/chapter06/02_vulkan_cameras/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter06/02_vulkan_cameras/shader/assimp_skinning.frag
+++ b/chapter06/02_vulkan_cameras/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter06/02_vulkan_cameras/shader/assimp_skinning_selection.frag
+++ b/chapter06/02_vulkan_cameras/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter06/02_vulkan_cameras/shader/line.frag
+++ b/chapter06/02_vulkan_cameras/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter06/02_vulkan_cameras/vulkan/VkRenderer.cpp
+++ b/chapter06/02_vulkan_cameras/vulkan/VkRenderer.cpp
@@ -1475,10 +1475,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter07/01_opengl_animations/opengl/Framebuffer.cpp
+++ b/chapter07/01_opengl_animations/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter07/01_opengl_animations/opengl/OGLRenderer.cpp
+++ b/chapter07/01_opengl_animations/opengl/OGLRenderer.cpp
@@ -115,6 +115,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -1739,10 +1743,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter07/01_opengl_animations/shader/assimp.frag
+++ b/chapter07/01_opengl_animations/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter07/01_opengl_animations/shader/assimp_selection.frag
+++ b/chapter07/01_opengl_animations/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter07/01_opengl_animations/shader/assimp_skinning.frag
+++ b/chapter07/01_opengl_animations/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter07/01_opengl_animations/shader/assimp_skinning_selection.frag
+++ b/chapter07/01_opengl_animations/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter07/01_opengl_animations/shader/line.frag
+++ b/chapter07/01_opengl_animations/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter07/02_vulkan_animations/shader/assimp.frag
+++ b/chapter07/02_vulkan_animations/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter07/02_vulkan_animations/shader/assimp_selection.frag
+++ b/chapter07/02_vulkan_animations/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter07/02_vulkan_animations/shader/assimp_skinning.frag
+++ b/chapter07/02_vulkan_animations/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter07/02_vulkan_animations/shader/assimp_skinning_selection.frag
+++ b/chapter07/02_vulkan_animations/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter07/02_vulkan_animations/shader/line.frag
+++ b/chapter07/02_vulkan_animations/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter07/02_vulkan_animations/vulkan/VkRenderer.cpp
+++ b/chapter07/02_vulkan_animations/vulkan/VkRenderer.cpp
@@ -1527,10 +1527,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter08/01_opengl_collisions/opengl/Framebuffer.cpp
+++ b/chapter08/01_opengl_collisions/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter08/01_opengl_collisions/opengl/OGLRenderer.cpp
+++ b/chapter08/01_opengl_collisions/opengl/OGLRenderer.cpp
@@ -125,6 +125,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -2453,10 +2457,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter08/01_opengl_collisions/shader/assimp.frag
+++ b/chapter08/01_opengl_collisions/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter08/01_opengl_collisions/shader/assimp_selection.frag
+++ b/chapter08/01_opengl_collisions/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter08/01_opengl_collisions/shader/assimp_skinning.frag
+++ b/chapter08/01_opengl_collisions/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter08/01_opengl_collisions/shader/assimp_skinning_selection.frag
+++ b/chapter08/01_opengl_collisions/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter08/01_opengl_collisions/shader/line.frag
+++ b/chapter08/01_opengl_collisions/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter08/01_opengl_collisions/shader/sphere_instance.frag
+++ b/chapter08/01_opengl_collisions/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter08/02_vulkan_collisions/shader/assimp.frag
+++ b/chapter08/02_vulkan_collisions/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter08/02_vulkan_collisions/shader/assimp_selection.frag
+++ b/chapter08/02_vulkan_collisions/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter08/02_vulkan_collisions/shader/assimp_skinning.frag
+++ b/chapter08/02_vulkan_collisions/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter08/02_vulkan_collisions/shader/assimp_skinning_selection.frag
+++ b/chapter08/02_vulkan_collisions/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter08/02_vulkan_collisions/shader/line.frag
+++ b/chapter08/02_vulkan_collisions/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter08/02_vulkan_collisions/shader/sphere_instance.frag
+++ b/chapter08/02_vulkan_collisions/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter08/02_vulkan_collisions/vulkan/VkRenderer.cpp
+++ b/chapter08/02_vulkan_collisions/vulkan/VkRenderer.cpp
@@ -1904,10 +1904,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter09/01_opengl_behavior/opengl/Framebuffer.cpp
+++ b/chapter09/01_opengl_behavior/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter09/01_opengl_behavior/opengl/OGLRenderer.cpp
+++ b/chapter09/01_opengl_behavior/opengl/OGLRenderer.cpp
@@ -122,6 +122,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -2942,10 +2946,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter09/01_opengl_behavior/shader/assimp.frag
+++ b/chapter09/01_opengl_behavior/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter09/01_opengl_behavior/shader/assimp_selection.frag
+++ b/chapter09/01_opengl_behavior/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter09/01_opengl_behavior/shader/assimp_skinning.frag
+++ b/chapter09/01_opengl_behavior/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter09/01_opengl_behavior/shader/assimp_skinning_selection.frag
+++ b/chapter09/01_opengl_behavior/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter09/01_opengl_behavior/shader/line.frag
+++ b/chapter09/01_opengl_behavior/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter09/01_opengl_behavior/shader/sphere_instance.frag
+++ b/chapter09/01_opengl_behavior/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter09/02_vulkan_behavior/shader/assimp.frag
+++ b/chapter09/02_vulkan_behavior/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter09/02_vulkan_behavior/shader/assimp_selection.frag
+++ b/chapter09/02_vulkan_behavior/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter09/02_vulkan_behavior/shader/assimp_skinning.frag
+++ b/chapter09/02_vulkan_behavior/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter09/02_vulkan_behavior/shader/assimp_skinning_selection.frag
+++ b/chapter09/02_vulkan_behavior/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter09/02_vulkan_behavior/shader/line.frag
+++ b/chapter09/02_vulkan_behavior/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter09/02_vulkan_behavior/shader/sphere_instance.frag
+++ b/chapter09/02_vulkan_behavior/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter09/02_vulkan_behavior/vulkan/VkRenderer.cpp
+++ b/chapter09/02_vulkan_behavior/vulkan/VkRenderer.cpp
@@ -1998,10 +1998,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter10/01_opengl_morphanim/opengl/Framebuffer.cpp
+++ b/chapter10/01_opengl_morphanim/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter10/01_opengl_morphanim/opengl/OGLRenderer.cpp
+++ b/chapter10/01_opengl_morphanim/opengl/OGLRenderer.cpp
@@ -143,6 +143,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -3072,10 +3076,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter10/01_opengl_morphanim/shader/assimp.frag
+++ b/chapter10/01_opengl_morphanim/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter10/01_opengl_morphanim/shader/assimp_selection.frag
+++ b/chapter10/01_opengl_morphanim/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter10/01_opengl_morphanim/shader/assimp_skinning.frag
+++ b/chapter10/01_opengl_morphanim/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter10/01_opengl_morphanim/shader/assimp_skinning_morph.frag
+++ b/chapter10/01_opengl_morphanim/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,5 +31,6 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }
 

--- a/chapter10/01_opengl_morphanim/shader/assimp_skinning_morph_selection.frag
+++ b/chapter10/01_opengl_morphanim/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter10/01_opengl_morphanim/shader/assimp_skinning_selection.frag
+++ b/chapter10/01_opengl_morphanim/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter10/01_opengl_morphanim/shader/line.frag
+++ b/chapter10/01_opengl_morphanim/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter10/01_opengl_morphanim/shader/sphere_instance.frag
+++ b/chapter10/01_opengl_morphanim/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter10/02_vulkan_morphanim/shader/assimp.frag
+++ b/chapter10/02_vulkan_morphanim/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter10/02_vulkan_morphanim/shader/assimp_selection.frag
+++ b/chapter10/02_vulkan_morphanim/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter10/02_vulkan_morphanim/shader/assimp_skinning.frag
+++ b/chapter10/02_vulkan_morphanim/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter10/02_vulkan_morphanim/shader/assimp_skinning_morph.frag
+++ b/chapter10/02_vulkan_morphanim/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter10/02_vulkan_morphanim/shader/assimp_skinning_morph_selection.frag
+++ b/chapter10/02_vulkan_morphanim/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter10/02_vulkan_morphanim/shader/assimp_skinning_selection.frag
+++ b/chapter10/02_vulkan_morphanim/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter10/02_vulkan_morphanim/shader/line.frag
+++ b/chapter10/02_vulkan_morphanim/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter10/02_vulkan_morphanim/shader/sphere_instance.frag
+++ b/chapter10/02_vulkan_morphanim/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter10/02_vulkan_morphanim/vulkan/VkRenderer.cpp
+++ b/chapter10/02_vulkan_morphanim/vulkan/VkRenderer.cpp
@@ -2321,10 +2321,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter11/01_opengl_level/opengl/Framebuffer.cpp
+++ b/chapter11/01_opengl_level/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter11/01_opengl_level/opengl/OGLRenderer.cpp
+++ b/chapter11/01_opengl_level/opengl/OGLRenderer.cpp
@@ -148,6 +148,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -3275,10 +3279,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter11/01_opengl_level/shader/assimp.frag
+++ b/chapter11/01_opengl_level/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter11/01_opengl_level/shader/assimp_level.frag
+++ b/chapter11/01_opengl_level/shader/assimp_level.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter11/01_opengl_level/shader/assimp_selection.frag
+++ b/chapter11/01_opengl_level/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter11/01_opengl_level/shader/assimp_skinning.frag
+++ b/chapter11/01_opengl_level/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter11/01_opengl_level/shader/assimp_skinning_morph.frag
+++ b/chapter11/01_opengl_level/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,5 +31,6 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }
 

--- a/chapter11/01_opengl_level/shader/assimp_skinning_morph_selection.frag
+++ b/chapter11/01_opengl_level/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter11/01_opengl_level/shader/assimp_skinning_selection.frag
+++ b/chapter11/01_opengl_level/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter11/01_opengl_level/shader/line.frag
+++ b/chapter11/01_opengl_level/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter11/01_opengl_level/shader/sphere_instance.frag
+++ b/chapter11/01_opengl_level/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter11/02_vulkan_level/shader/assimp.frag
+++ b/chapter11/02_vulkan_level/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter11/02_vulkan_level/shader/assimp_level.frag
+++ b/chapter11/02_vulkan_level/shader/assimp_level.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter11/02_vulkan_level/shader/assimp_selection.frag
+++ b/chapter11/02_vulkan_level/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter11/02_vulkan_level/shader/assimp_skinning.frag
+++ b/chapter11/02_vulkan_level/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter11/02_vulkan_level/shader/assimp_skinning_morph.frag
+++ b/chapter11/02_vulkan_level/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter11/02_vulkan_level/shader/assimp_skinning_morph_selection.frag
+++ b/chapter11/02_vulkan_level/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter11/02_vulkan_level/shader/assimp_skinning_selection.frag
+++ b/chapter11/02_vulkan_level/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter11/02_vulkan_level/shader/line.frag
+++ b/chapter11/02_vulkan_level/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter11/02_vulkan_level/shader/sphere_instance.frag
+++ b/chapter11/02_vulkan_level/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter11/02_vulkan_level/vulkan/VkRenderer.cpp
+++ b/chapter11/02_vulkan_level/vulkan/VkRenderer.cpp
@@ -2460,10 +2460,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter12/01_opengl_adv_collision/opengl/Framebuffer.cpp
+++ b/chapter12/01_opengl_adv_collision/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter12/01_opengl_adv_collision/opengl/OGLRenderer.cpp
+++ b/chapter12/01_opengl_adv_collision/opengl/OGLRenderer.cpp
@@ -153,6 +153,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -3858,10 +3862,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter12/01_opengl_adv_collision/shader/assimp.frag
+++ b/chapter12/01_opengl_adv_collision/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter12/01_opengl_adv_collision/shader/assimp_level.frag
+++ b/chapter12/01_opengl_adv_collision/shader/assimp_level.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter12/01_opengl_adv_collision/shader/assimp_selection.frag
+++ b/chapter12/01_opengl_adv_collision/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter12/01_opengl_adv_collision/shader/assimp_skinning.frag
+++ b/chapter12/01_opengl_adv_collision/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter12/01_opengl_adv_collision/shader/assimp_skinning_morph.frag
+++ b/chapter12/01_opengl_adv_collision/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,5 +31,6 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }
 

--- a/chapter12/01_opengl_adv_collision/shader/assimp_skinning_morph_selection.frag
+++ b/chapter12/01_opengl_adv_collision/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter12/01_opengl_adv_collision/shader/assimp_skinning_selection.frag
+++ b/chapter12/01_opengl_adv_collision/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter12/01_opengl_adv_collision/shader/line.frag
+++ b/chapter12/01_opengl_adv_collision/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter12/01_opengl_adv_collision/shader/sphere_instance.frag
+++ b/chapter12/01_opengl_adv_collision/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter12/02_vulkan_adv_collision/shader/assimp.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter12/02_vulkan_adv_collision/shader/assimp_level.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/assimp_level.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter12/02_vulkan_adv_collision/shader/assimp_selection.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter12/02_vulkan_adv_collision/shader/assimp_skinning.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter12/02_vulkan_adv_collision/shader/assimp_skinning_morph.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter12/02_vulkan_adv_collision/shader/assimp_skinning_morph_selection.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter12/02_vulkan_adv_collision/shader/assimp_skinning_selection.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter12/02_vulkan_adv_collision/shader/line.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter12/02_vulkan_adv_collision/shader/sphere_instance.frag
+++ b/chapter12/02_vulkan_adv_collision/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter12/02_vulkan_adv_collision/vulkan/VkRenderer.cpp
+++ b/chapter12/02_vulkan_adv_collision/vulkan/VkRenderer.cpp
@@ -2527,10 +2527,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter13/01_opengl_navigation/opengl/Framebuffer.cpp
+++ b/chapter13/01_opengl_navigation/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter13/01_opengl_navigation/opengl/OGLRenderer.cpp
+++ b/chapter13/01_opengl_navigation/opengl/OGLRenderer.cpp
@@ -163,6 +163,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -4153,10 +4157,7 @@ bool OGLRenderer::draw(float deltaTime) {
   mFramebuffer.unbind();
 
   /* blit color buffer to screen */
-  /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter13/01_opengl_navigation/shader/assimp.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter13/01_opengl_navigation/shader/assimp_groundmesh.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp_groundmesh.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 color;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = color;
+  FragColor = vec4(sRGB(color.rgb), color.a);
 }

--- a/chapter13/01_opengl_navigation/shader/assimp_level.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp_level.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter13/01_opengl_navigation/shader/assimp_selection.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter13/01_opengl_navigation/shader/assimp_skinning.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter13/01_opengl_navigation/shader/assimp_skinning_morph.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,5 +31,6 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }
 

--- a/chapter13/01_opengl_navigation/shader/assimp_skinning_morph_selection.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter13/01_opengl_navigation/shader/assimp_skinning_selection.frag
+++ b/chapter13/01_opengl_navigation/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter13/01_opengl_navigation/shader/line.frag
+++ b/chapter13/01_opengl_navigation/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter13/01_opengl_navigation/shader/sphere_instance.frag
+++ b/chapter13/01_opengl_navigation/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter13/02_vulkan_navigation/shader/assimp.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter13/02_vulkan_navigation/shader/assimp_groundmesh.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp_groundmesh.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 color;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = color;
+  FragColor = vec4(sRGB(color.rgb), color.a);
 }

--- a/chapter13/02_vulkan_navigation/shader/assimp_level.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp_level.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter13/02_vulkan_navigation/shader/assimp_selection.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter13/02_vulkan_navigation/shader/assimp_skinning.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp_skinning.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter13/02_vulkan_navigation/shader/assimp_skinning_morph.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp_skinning_morph.frag
@@ -10,6 +10,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -21,4 +31,5 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter13/02_vulkan_navigation/shader/assimp_skinning_morph_selection.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp_skinning_morph_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter13/02_vulkan_navigation/shader/assimp_skinning_selection.frag
+++ b/chapter13/02_vulkan_navigation/shader/assimp_skinning_selection.frag
@@ -12,6 +12,16 @@ layout (set = 0, binding = 0) uniform sampler2D tex;
 vec3 lightPos = vec3(4.0, 3.0, 6.0);
 vec3 lightColor = vec3(1.0, 1.0, 1.0);
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -23,6 +33,7 @@ void main() {
   vec3 diffuse = diff * vec3(lightColor);
 
   FragColor = vec4(ambient + diffuse, 1.0) * texture(tex, texCoord) * color;
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter13/02_vulkan_navigation/shader/line.frag
+++ b/chapter13/02_vulkan_navigation/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter13/02_vulkan_navigation/shader/sphere_instance.frag
+++ b/chapter13/02_vulkan_navigation/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter13/02_vulkan_navigation/vulkan/VkRenderer.cpp
+++ b/chapter13/02_vulkan_navigation/vulkan/VkRenderer.cpp
@@ -2601,10 +2601,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild

--- a/chapter14/01_opengl_ideas/opengl/Framebuffer.cpp
+++ b/chapter14/01_opengl_ideas/opengl/Framebuffer.cpp
@@ -11,7 +11,7 @@ bool Framebuffer::init(unsigned int width, unsigned int height) {
   /* color texture */
   glGenTextures(1, &mColorTex);
   glBindTexture(GL_TEXTURE_2D, mColorTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/chapter14/01_opengl_ideas/opengl/OGLRenderer.cpp
+++ b/chapter14/01_opengl_ideas/opengl/OGLRenderer.cpp
@@ -183,6 +183,10 @@ bool OGLRenderer::init(unsigned int width, unsigned int height) {
   glEnable(GL_CULL_FACE);
   glEnable(GL_DEPTH_TEST);
   glLineWidth(3.0);
+
+  /* disable sRGB framebuffer */
+  glDisable(GL_FRAMEBUFFER_SRGB);
+
   Logger::log(1, "%s: rendering defaults set\n", __FUNCTION__);
 
   /* SSBO init  */
@@ -4308,9 +4312,7 @@ bool OGLRenderer::draw(float deltaTime) {
 
   /* blit color buffer to screen */
   /* XXX: enable sRGB ONLY for the final framebuffer draw */
-  glEnable(GL_FRAMEBUFFER_SRGB);
   mFramebuffer.drawToScreen();
-  glDisable(GL_FRAMEBUFFER_SRGB);
 
   /* create user interface */
   mUIGenerateTimer.start();

--- a/chapter14/01_opengl_ideas/shader/assimp.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp.frag
@@ -15,6 +15,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,6 +40,7 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 
 }
 

--- a/chapter14/01_opengl_ideas/shader/assimp_groundmesh.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp_groundmesh.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 color;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = color;
+  FragColor = vec4(sRGB(color.rgb), color.a);
 }

--- a/chapter14/01_opengl_ideas/shader/assimp_level.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp_level.frag
@@ -15,6 +15,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,4 +40,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/01_opengl_ideas/shader/assimp_selection.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp_selection.frag
@@ -17,6 +17,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -32,6 +42,7 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter14/01_opengl_ideas/shader/assimp_skinning.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp_skinning.frag
@@ -15,6 +15,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,4 +40,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/01_opengl_ideas/shader/assimp_skinning_morph.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp_skinning_morph.frag
@@ -15,6 +15,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,5 +40,6 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }
 

--- a/chapter14/01_opengl_ideas/shader/assimp_skinning_morph_selection.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp_skinning_morph_selection.frag
@@ -17,6 +17,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -32,6 +42,7 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter14/01_opengl_ideas/shader/assimp_skinning_selection.frag
+++ b/chapter14/01_opengl_ideas/shader/assimp_skinning_selection.frag
@@ -17,6 +17,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -32,6 +42,7 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter14/01_opengl_ideas/shader/line.frag
+++ b/chapter14/01_opengl_ideas/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter14/01_opengl_ideas/shader/skybox.frag
+++ b/chapter14/01_opengl_ideas/shader/skybox.frag
@@ -13,6 +13,16 @@ layout (std140, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   /* scale up fog density to hide skybox */
   float boxFogDensity = 200.0 * fogDensity;
@@ -22,4 +32,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(texture(tex, texCoord) * vec4(vec3(lightColor), 1.0), fogColor, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/01_opengl_ideas/shader/sphere_instance.frag
+++ b/chapter14/01_opengl_ideas/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter14/02_vulkan_ideas/shader/assimp.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp.frag
@@ -15,6 +15,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,4 +40,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/02_vulkan_ideas/shader/assimp_groundmesh.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp_groundmesh.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 color;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = color;
+  FragColor = vec4(sRGB(color.rgb), color.a);
 }

--- a/chapter14/02_vulkan_ideas/shader/assimp_level.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp_level.frag
@@ -15,6 +15,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,4 +40,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/02_vulkan_ideas/shader/assimp_selection.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp_selection.frag
@@ -17,6 +17,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -32,6 +42,7 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter14/02_vulkan_ideas/shader/assimp_skinning.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp_skinning.frag
@@ -15,6 +15,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,4 +40,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/02_vulkan_ideas/shader/assimp_skinning_morph.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp_skinning_morph.frag
@@ -15,6 +15,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -30,4 +40,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/02_vulkan_ideas/shader/assimp_skinning_morph_selection.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp_skinning_morph_selection.frag
@@ -17,6 +17,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -32,6 +42,7 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter14/02_vulkan_ideas/shader/assimp_skinning_selection.frag
+++ b/chapter14/02_vulkan_ideas/shader/assimp_skinning_selection.frag
@@ -17,6 +17,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   float ambientStrength = 0.1;
   vec3 ambient = ambientStrength * max(vec3(lightColor), vec3(0.05, 0.05, 0.05));
@@ -32,6 +42,7 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(vec4(min(ambient + diffuse, vec3(1.0)), 1.0) * texture(tex, texCoord) * color, fogColor * color, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 
   /* fill the second color attachment with the ID of our model */
   SelectedInstance = selectInfo;

--- a/chapter14/02_vulkan_ideas/shader/line.frag
+++ b/chapter14/02_vulkan_ideas/shader/line.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter14/02_vulkan_ideas/shader/skybox.frag
+++ b/chapter14/02_vulkan_ideas/shader/skybox.frag
@@ -13,6 +13,16 @@ layout (std140, set = 1, binding = 0) uniform Matrices {
   float fogDensity;
 };
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
   /* scale up fog density to hide skybox */
   float boxFogDensity = 200.0 * fogDensity;
@@ -22,4 +32,5 @@ void main() {
   vec4 fogColor = 0.25 * vec4(vec3(lightColor), 1.0);
 
   FragColor = mix(texture(tex, texCoord) * vec4(vec3(lightColor), 1.0), fogColor, fogAmount);
+  FragColor.rgb = sRGB(FragColor.rgb);
 }

--- a/chapter14/02_vulkan_ideas/shader/sphere_instance.frag
+++ b/chapter14/02_vulkan_ideas/shader/sphere_instance.frag
@@ -3,6 +3,16 @@ layout (location = 0) in vec4 lineColor;
 
 layout (location = 0) out vec4 FragColor;
 
+float toSRGB(float x) {
+if (x <= 0.0031308)
+        return 12.92 * x;
+    else
+        return 1.055 * pow(x, (1.0/2.4)) - 0.055;
+}
+vec3 sRGB(vec3 c) {
+    return vec3(toSRGB(c.x), toSRGB(c.y), toSRGB(c.z));
+}
+
 void main() {
-  FragColor = lineColor;
+  FragColor = vec4(sRGB(lineColor.rgb), lineColor.a);
 }

--- a/chapter14/02_vulkan_ideas/vulkan/VkRenderer.cpp
+++ b/chapter14/02_vulkan_ideas/vulkan/VkRenderer.cpp
@@ -2702,10 +2702,9 @@ bool VkRenderer::createSwapchain() {
   vkb::SwapchainBuilder swapChainBuild{mRenderData.rdVkbDevice};
   VkSurfaceFormatKHR surfaceFormat;
 
-  /* set surface to sRGB */
+  /* set surface to non-sRGB */
   surfaceFormat.colorSpace = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-  //surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
-  surfaceFormat.format = VK_FORMAT_B8G8R8A8_SRGB;
+  surfaceFormat.format = VK_FORMAT_B8G8R8A8_UNORM;
 
   /* VK_PRESENT_MODE_FIFO_KHR enables vsync */
   auto  swapChainBuildRet = swapChainBuild


### PR DESCRIPTION
Do color correction in fragment shaders

Node: Wrong branch, should be `9-fix-srgb-conversions-for-opengl-and-vulkan-on-windows-linux`