### PR TITLE
Moved line/sphere creation and update code before draw start

### DIFF
--- a/chapter03/02_vulkan_selection/vulkan/VkRenderer.cpp
+++ b/chapter03/02_vulkan_selection/vulkan/VkRenderer.cpp
@@ -2296,6 +2296,36 @@ bool VkRenderer::draw(float deltaTime) {
     updateDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mCoordArrowsLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+  if (mModelInstData.miSelectedInstance > 0) {
+    InstanceSettings instSettings = mModelInstData.miAssimpInstances.at(mModelInstData.miSelectedInstance)->getInstanceSettings();
+
+    /* draw coordiante arrows at origin of selected instance */
+    switch(mRenderData.rdInstanceEditMode) {
+      case instanceEditMode::move:
+        mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+        break;
+      case instanceEditMode::rotate:
+        mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+        break;
+      case instanceEditMode::scale:
+        mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+        break;
+    }
+
+    mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
+    std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+      [=](auto &n) {
+        n.color /= 2.0f;
+        n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+        n.position += instSettings.isWorldPosition;
+      });
+    mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+      mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+  }
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -2446,36 +2476,6 @@ bool VkRenderer::draw(float deltaTime) {
   if (!CommandBuffer::end(mRenderData.rdCommandBuffer)) {
     Logger::log(1, "%s error: failed to end command buffer\n", __FUNCTION__);
     return false;
-  }
-
-  /* draw coordinate lines */
-  mCoordArrowsLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-  if (mModelInstData.miSelectedInstance > 0) {
-    InstanceSettings instSettings = mModelInstData.miAssimpInstances.at(mModelInstData.miSelectedInstance)->getInstanceSettings();
-
-    /* draw coordiante arrows at origin of selected instance */
-    switch(mRenderData.rdInstanceEditMode) {
-      case instanceEditMode::move:
-        mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-        break;
-      case instanceEditMode::rotate:
-        mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-        break;
-      case instanceEditMode::scale:
-        mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-        break;
-    }
-
-    mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
-    std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                  [=](auto &n) {
-                    n.color /= 2.0f;
-                    n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                    n.position += instSettings.isWorldPosition;
-                  });
-    mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-                               mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
   }
 
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {

--- a/chapter04/02_vulkan_edit_view_mode/vulkan/VkRenderer.cpp
+++ b/chapter04/02_vulkan_edit_view_mode/vulkan/VkRenderer.cpp
@@ -2402,6 +2402,38 @@ bool VkRenderer::draw(float deltaTime) {
     updateDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mCoordArrowsLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstData.miSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstData.miAssimpInstances.at(mModelInstData.miSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+        [=](auto &n) {
+          n.color /= 2.0f;
+          n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+          n.position += instSettings.isWorldPosition;
+        });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -2552,38 +2584,6 @@ bool VkRenderer::draw(float deltaTime) {
   if (!CommandBuffer::end(mRenderData.rdCommandBuffer)) {
     Logger::log(1, "%s error: failed to end command buffer\n", __FUNCTION__);
     return false;
-  }
-
-  /* draw coordinate lines */
-  mCoordArrowsLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstData.miSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstData.miAssimpInstances.at(mModelInstData.miSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-                                 mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
   }
 
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {

--- a/chapter05/02_vulkan_load_save/vulkan/VkRenderer.cpp
+++ b/chapter05/02_vulkan_load_save/vulkan/VkRenderer.cpp
@@ -2721,6 +2721,38 @@ bool VkRenderer::draw(float deltaTime) {
     updateDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mCoordArrowsLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstData.miSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstData.miAssimpInstances.at(mModelInstData.miSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+        [=](auto &n) {
+          n.color /= 2.0f;
+          n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+          n.position += instSettings.isWorldPosition;
+        });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -2871,38 +2903,6 @@ bool VkRenderer::draw(float deltaTime) {
   if (!CommandBuffer::end(mRenderData.rdCommandBuffer)) {
     Logger::log(1, "%s error: failed to end command buffer\n", __FUNCTION__);
     return false;
-  }
-
-  /* draw coordinate lines */
-  mCoordArrowsLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstData.miSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstData.miAssimpInstances.at(mModelInstData.miSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-                                 mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
   }
 
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {

--- a/chapter06/02_vulkan_cameras/vulkan/VkRenderer.cpp
+++ b/chapter06/02_vulkan_cameras/vulkan/VkRenderer.cpp
@@ -3066,6 +3066,38 @@ bool VkRenderer::draw(float deltaTime) {
     updateDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mCoordArrowsLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstCamData.micSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+        [=](auto &n) {
+          n.color /= 2.0f;
+          n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+          n.position += instSettings.isWorldPosition;
+        });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -3216,38 +3248,6 @@ bool VkRenderer::draw(float deltaTime) {
   if (!CommandBuffer::end(mRenderData.rdCommandBuffer)) {
     Logger::log(1, "%s error: failed to end command buffer\n", __FUNCTION__);
     return false;
-  }
-
-  /* draw coordinate lines */
-  mCoordArrowsLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstCamData.micSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mCoordArrowsLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-                                 mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
   }
 
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {

--- a/chapter08/02_vulkan_collisions/vulkan/VkRenderer.cpp
+++ b/chapter08/02_vulkan_collisions/vulkan/VkRenderer.cpp
@@ -4693,6 +4693,68 @@ bool VkRenderer::draw(float deltaTime) {
     updateDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstCamData.micSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+        [=](auto &n) {
+          n.color /= 2.0f;
+          n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+          n.position += instSettings.isWorldPosition;
+        });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
+  /* create AABB lines and bounding sphere of selected instance */
+  mCollisionDebugDrawTimer.start();
+  if (mRenderData.rdDrawCollisionAABBs == collisionDebugDraw::colliding || mRenderData.rdDrawCollisionAABBs == collisionDebugDraw::all) {
+    drawAABBs();
+  }
+
+  /* create colliding spheres */
+  mCollidingSphereCount = 0;
+  uint32_t sphereVertexCount = 0;
+
+  switch (mRenderData.rdDrawBoundingSpheres) {
+    case collisionDebugDraw::none:
+      break;
+    case collisionDebugDraw::colliding:
+      if (!mModelInstCamData.micInstanceCollisions.empty()) {
+        createCollidingBoundingSpheres();
+        sphereVertexCount = mCollidingSphereMesh.vertices.size();
+      }
+      break;
+    case collisionDebugDraw::selected:
+      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
+      createSelectedBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+    case collisionDebugDraw::all:
+      createAllBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+  }
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -4845,44 +4907,6 @@ bool VkRenderer::draw(float deltaTime) {
     return false;
   }
 
-  /* draw coordinate lines */
-  mLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstCamData.micSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-                                 mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
-  }
-
-  /* draw AABB lines and bounding sphere of selected instance */
-  mCollisionDebugDrawTimer.start();
-  if (mRenderData.rdDrawCollisionAABBs == collisionDebugDraw::colliding || mRenderData.rdDrawCollisionAABBs == collisionDebugDraw::all) {
-    drawAABBs();
-  }
-
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {
     Logger::log(1, "%s error: failed to reset line drawing command buffer\n", __FUNCTION__);
     return false;
@@ -4915,30 +4939,6 @@ bool VkRenderer::draw(float deltaTime) {
     vkCmdBindVertexBuffers(mRenderData.rdLineCommandBuffer, 0, 1, &mLineVertexBuffer.buffer, &offset);
     vkCmdSetLineWidth(mRenderData.rdLineCommandBuffer, 3.0f);
     vkCmdDraw(mRenderData.rdLineCommandBuffer, static_cast<uint32_t>(mLineMesh->vertices.size()), 1, 0, 0);
-  }
-
-  /* draw colliding spheres */
-  mCollidingSphereCount = 0;
-  uint32_t sphereVertexCount = 0;
-
-  switch (mRenderData.rdDrawBoundingSpheres) {
-    case collisionDebugDraw::none:
-      break;
-    case collisionDebugDraw::colliding:
-      if (!mModelInstCamData.micInstanceCollisions.empty()) {
-        createCollidingBoundingSpheres();
-        sphereVertexCount = mCollidingSphereMesh.vertices.size();
-      }
-      break;
-    case collisionDebugDraw::selected:
-      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
-      createSelectedBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
-    case collisionDebugDraw::all:
-      createAllBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
   }
 
   /* draw colliding spheres */

--- a/chapter09/02_vulkan_behavior/vulkan/VkRenderer.cpp
+++ b/chapter09/02_vulkan_behavior/vulkan/VkRenderer.cpp
@@ -5160,6 +5160,76 @@ bool VkRenderer::draw(float deltaTime) {
     updateDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstCamData.micSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+        [=](auto &n) {
+          n.color /= 2.0f;
+          n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+          n.position += instSettings.isWorldPosition;
+        });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
+  /* debug for interaction */
+  mInteractionTimer.start();
+  drawInteractionDebug();
+  mRenderData.rdInteractionTime += mInteractionTimer.stop();
+
+  /* create AABB lines and bounding sphere of selected instance */
+  mCollisionDebugDrawTimer.start();
+  drawCollisionDebug();
+
+  /* create bounding spheres */
+  mCollidingSphereCount = 0;
+  uint32_t sphereVertexCount = 0;
+
+  switch (mRenderData.rdDrawBoundingSpheres) {
+    case collisionDebugDraw::none:
+      break;
+    case collisionDebugDraw::colliding:
+      if (!mModelInstCamData.micInstanceCollisions.empty()) {
+        createCollidingBoundingSpheres();
+        sphereVertexCount = mCollidingSphereMesh.vertices.size();
+      }
+      break;
+    case collisionDebugDraw::selected:
+      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
+      createSelectedBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+    case collisionDebugDraw::all:
+      createAllBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+  }
+
+  /* behavior update */
+  mBehviorTimer.start();
+  mBehaviorManager->update(deltaTime);
+  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -5312,47 +5382,6 @@ bool VkRenderer::draw(float deltaTime) {
     return false;
   }
 
-  /* draw coordinate lines */
-  mLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstCamData.micSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
-  }
-
-  /* debug for interaction */
-  mInteractionTimer.start();
-  drawInteractionDebug();
-  mRenderData.rdInteractionTime += mInteractionTimer.stop();
-
-  /* draw AABB lines and bounding sphere of selected instance */
-  mCollisionDebugDrawTimer.start();
-  drawCollisionDebug();
-
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {
     Logger::log(1, "%s error: failed to reset line drawing command buffer\n", __FUNCTION__);
     return false;
@@ -5387,30 +5416,6 @@ bool VkRenderer::draw(float deltaTime) {
     vkCmdDraw(mRenderData.rdLineCommandBuffer, static_cast<uint32_t>(mLineMesh->vertices.size()), 1, 0, 0);
   }
 
-  /* draw bounding spheres */
-  mCollidingSphereCount = 0;
-  uint32_t sphereVertexCount = 0;
-
-  switch (mRenderData.rdDrawBoundingSpheres) {
-    case collisionDebugDraw::none:
-      break;
-    case collisionDebugDraw::colliding:
-      if (!mModelInstCamData.micInstanceCollisions.empty()) {
-        createCollidingBoundingSpheres();
-        sphereVertexCount = mCollidingSphereMesh.vertices.size();
-      }
-      break;
-    case collisionDebugDraw::selected:
-      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
-      createSelectedBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
-    case collisionDebugDraw::all:
-      createAllBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
-  }
-
   /* draw colliding spheres */
   if (mCollidingSphereCount > 0) {
     vkCmdBindPipeline(mRenderData.rdLineCommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, mRenderData.rdSpherePipeline);
@@ -5431,11 +5436,6 @@ bool VkRenderer::draw(float deltaTime) {
     Logger::log(1, "%s error: failed to end line drawing command buffer\n", __FUNCTION__);
     return false;
   }
-
-  /* behavior update */
-  mBehviorTimer.start();
-  mBehaviorManager->update(deltaTime);
-  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
 
   /* imGui overlay */
   mUIGenerateTimer.start();
@@ -5494,13 +5494,8 @@ bool VkRenderer::draw(float deltaTime) {
   VkSubmitInfo submitInfo{};
   submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
-  //std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdComputeSemaphore, m//RenderData.rdPresentSemaphore };
-  //std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
-
   std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdPresentSemaphore };
   std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
-  /* compute shader: contine if in vertex input ready
-   * vertex shader: wait for color attachment output ready */
   submitInfo.pWaitDstStageMask = waitStages.data();
 
   submitInfo.waitSemaphoreCount = static_cast<uint32_t>(waitSemaphores.size());

--- a/chapter10/02_vulkan_morphanim/vulkan/VkRenderer.cpp
+++ b/chapter10/02_vulkan_morphanim/vulkan/VkRenderer.cpp
@@ -5604,6 +5604,76 @@ bool VkRenderer::draw(float deltaTime) {
     updateDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstCamData.micSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+                    [=](auto &n) {
+                      n.color /= 2.0f;
+                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+                      n.position += instSettings.isWorldPosition;
+                    });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+                                 mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
+  /* debug for interaction */
+  mInteractionTimer.start();
+  drawInteractionDebug();
+  mRenderData.rdInteractionTime += mInteractionTimer.stop();
+
+  /* create AABB lines and bounding sphere of selected instance */
+  mCollisionDebugDrawTimer.start();
+  drawCollisionDebug();
+
+  /* create bounding spheres */
+  mCollidingSphereCount = 0;
+  uint32_t sphereVertexCount = 0;
+
+  switch (mRenderData.rdDrawBoundingSpheres) {
+    case collisionDebugDraw::none:
+      break;
+    case collisionDebugDraw::colliding:
+      if (!mModelInstCamData.micInstanceCollisions.empty()) {
+        createCollidingBoundingSpheres();
+        sphereVertexCount = mCollidingSphereMesh.vertices.size();
+      }
+      break;
+    case collisionDebugDraw::selected:
+      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
+      createSelectedBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+    case collisionDebugDraw::all:
+      createAllBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+  }
+
+  /* behavior update */
+  mBehviorTimer.start();
+  mBehaviorManager->update(deltaTime);
+  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -5795,47 +5865,6 @@ bool VkRenderer::draw(float deltaTime) {
     return false;
   }
 
-  /* draw coordinate lines */
-  mLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstCamData.micSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
-  }
-
-  /* debug for interaction */
-  mInteractionTimer.start();
-  drawInteractionDebug();
-  mRenderData.rdInteractionTime += mInteractionTimer.stop();
-
-  /* draw AABB lines and bounding sphere of selected instance */
-  mCollisionDebugDrawTimer.start();
-  drawCollisionDebug();
-
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {
     Logger::log(1, "%s error: failed to reset line drawing command buffer\n", __FUNCTION__);
     return false;
@@ -5870,30 +5899,6 @@ bool VkRenderer::draw(float deltaTime) {
     vkCmdDraw(mRenderData.rdLineCommandBuffer, static_cast<uint32_t>(mLineMesh->vertices.size()), 1, 0, 0);
   }
 
-  /* draw bounding spheres */
-  mCollidingSphereCount = 0;
-  uint32_t sphereVertexCount = 0;
-
-  switch (mRenderData.rdDrawBoundingSpheres) {
-    case collisionDebugDraw::none:
-      break;
-    case collisionDebugDraw::colliding:
-      if (!mModelInstCamData.micInstanceCollisions.empty()) {
-        createCollidingBoundingSpheres();
-        sphereVertexCount = mCollidingSphereMesh.vertices.size();
-      }
-      break;
-    case collisionDebugDraw::selected:
-      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
-      createSelectedBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
-    case collisionDebugDraw::all:
-      createAllBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
-  }
-
   /* draw colliding spheres */
   if (mCollidingSphereCount > 0) {
     vkCmdBindPipeline(mRenderData.rdLineCommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, mRenderData.rdSpherePipeline);
@@ -5914,12 +5919,6 @@ bool VkRenderer::draw(float deltaTime) {
     Logger::log(1, "%s error: failed to end line drawing command buffer\n", __FUNCTION__);
     return false;
   }
-
-  /* behavior update */
-  mBehviorTimer.start();
-  mBehaviorManager->update(deltaTime);
-  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
-
 
   /* imGui overlay */
   mUIGenerateTimer.start();
@@ -5978,13 +5977,8 @@ bool VkRenderer::draw(float deltaTime) {
   VkSubmitInfo submitInfo{};
   submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
-  //std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdComputeSemaphore, m//RenderData.rdPresentSemaphore };
-  //std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
-
   std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdPresentSemaphore };
   std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
-  /* compute shader: contine if in vertex input ready
-   * vertex shader: wait for color attachment output ready */
   submitInfo.pWaitDstStageMask = waitStages.data();
 
   submitInfo.waitSemaphoreCount = static_cast<uint32_t>(waitSemaphores.size());

--- a/chapter12/02_vulkan_adv_collision/vulkan/VkRenderer.cpp
+++ b/chapter12/02_vulkan_adv_collision/vulkan/VkRenderer.cpp
@@ -6663,6 +6663,85 @@ bool VkRenderer::draw(float deltaTime) {
     updateLevelDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+
+  /* Coordinate arrows */
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstCamData.micSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+                    [=](auto &n) {
+                      n.color /= 2.0f;
+                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+                      n.position += instSettings.isWorldPosition;
+                    });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
+  /* debug for interaction */
+  mInteractionTimer.start();
+  drawInteractionDebug();
+  mRenderData.rdInteractionTime += mInteractionTimer.stop();
+
+  /* level stuff */
+  if (mModelInstCamData.micLevels.size() > 1) {
+    mLevelCollisionTimer.start();
+    checkForLevelCollisions();
+    mRenderData.rdLevelCollisionTime += mLevelCollisionTimer.stop();
+  }
+
+  /* create AABB lines and bounding sphere of selected instance */
+  mCollisionDebugDrawTimer.start();
+  drawCollisionDebug();
+
+  /* create bounding spheres */
+  mCollidingSphereCount = 0;
+  uint32_t sphereVertexCount = 0;
+
+  switch (mRenderData.rdDrawBoundingSpheres) {
+    case collisionDebugDraw::none:
+      break;
+    case collisionDebugDraw::colliding:
+      if (!mModelInstCamData.micInstanceCollisions.empty()) {
+        createCollidingBoundingSpheres();
+        sphereVertexCount = mCollidingSphereMesh.vertices.size();
+      }
+      break;
+    case collisionDebugDraw::selected:
+      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
+      createSelectedBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+    case collisionDebugDraw::all:
+      createAllBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+  }
+
+  /* behavior update */
+  mBehviorTimer.start();
+  mBehaviorManager->update(deltaTime);
+  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -6894,56 +6973,6 @@ bool VkRenderer::draw(float deltaTime) {
     return false;
   }
 
-  /* draw coordinate lines */
-  mLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-
-  /* Coordinate arrows */
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstCamData.micSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
-  }
-
-  /* debug for interaction */
-  mInteractionTimer.start();
-  drawInteractionDebug();
-  mRenderData.rdInteractionTime += mInteractionTimer.stop();
-
-  /* level stuff */
-  if (mModelInstCamData.micLevels.size() > 1) {
-    mLevelCollisionTimer.start();
-    checkForLevelCollisions();
-    mRenderData.rdLevelCollisionTime += mLevelCollisionTimer.stop();
-  }
-
-  /* draw AABB lines and bounding sphere of selected instance */
-  mCollisionDebugDrawTimer.start();
-  drawCollisionDebug();
-
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {
     Logger::log(1, "%s error: failed to reset line drawing command buffer\n", __FUNCTION__);
     return false;
@@ -6976,30 +7005,6 @@ bool VkRenderer::draw(float deltaTime) {
     vkCmdBindVertexBuffers(mRenderData.rdLineCommandBuffer, 0, 1, &mLineVertexBuffer.buffer, &offset);
     vkCmdSetLineWidth(mRenderData.rdLineCommandBuffer, 3.0f);
     vkCmdDraw(mRenderData.rdLineCommandBuffer, static_cast<uint32_t>(mLineMesh->vertices.size()), 1, 0, 0);
-  }
-
-  /* draw bounding spheres */
-  mCollidingSphereCount = 0;
-  uint32_t sphereVertexCount = 0;
-
-  switch (mRenderData.rdDrawBoundingSpheres) {
-    case collisionDebugDraw::none:
-      break;
-    case collisionDebugDraw::colliding:
-      if (!mModelInstCamData.micInstanceCollisions.empty()) {
-        createCollidingBoundingSpheres();
-        sphereVertexCount = mCollidingSphereMesh.vertices.size();
-      }
-      break;
-    case collisionDebugDraw::selected:
-      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
-      createSelectedBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
-    case collisionDebugDraw::all:
-      createAllBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
   }
 
   /* draw colliding spheres */
@@ -7057,12 +7062,6 @@ bool VkRenderer::draw(float deltaTime) {
     return false;
   }
 
-  /* behavior update */
-  mBehviorTimer.start();
-  mBehaviorManager->update(deltaTime);
-  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
-
-
   /* imGui overlay */
   mUIGenerateTimer.start();
   mUserInterface.createFrame(mRenderData);
@@ -7119,11 +7118,6 @@ bool VkRenderer::draw(float deltaTime) {
   /* submit command buffer */
   VkSubmitInfo submitInfo{};
   submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-
-  /* compute shader: contine if vertex input ready
-   * vertex shader: wait for color attachment output ready */
-  //std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdComputeSemaphore, mRenderData.rdPresentSemaphore };
-  //std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
 
   std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdPresentSemaphore };
   std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };

--- a/chapter14/02_vulkan_ideas/vulkan/VkRenderer.cpp
+++ b/chapter14/02_vulkan_ideas/vulkan/VkRenderer.cpp
@@ -7225,6 +7225,85 @@ bool VkRenderer::draw(float deltaTime) {
     updateLevelDescriptorSets();
   }
 
+  /* create coordinate lines */
+  mLineIndexCount = 0;
+  mLineMesh->vertices.clear();
+
+  /* Coordinate arrows */
+  if (mRenderData.rdApplicationMode == appMode::edit) {
+    if (mModelInstCamData.micSelectedInstance > 0) {
+      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
+
+      /* draw coordiante arrows at origin of selected instance */
+      switch(mRenderData.rdInstanceEditMode) {
+        case instanceEditMode::move:
+          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::rotate:
+          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
+          break;
+        case instanceEditMode::scale:
+          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
+          break;
+      }
+
+      mLineIndexCount += mCoordArrowsMesh.vertices.size();
+      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
+                    [=](auto &n) {
+                      n.color /= 2.0f;
+                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
+                      n.position += instSettings.isWorldPosition;
+                    });
+      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
+        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
+    }
+  }
+
+  /* debug for interaction */
+  mInteractionTimer.start();
+  drawInteractionDebug();
+  mRenderData.rdInteractionTime += mInteractionTimer.stop();
+
+  /* level stuff */
+  if (mModelInstCamData.micLevels.size() > 1) {
+    mLevelCollisionTimer.start();
+    checkForLevelCollisions();
+    mRenderData.rdLevelCollisionTime += mLevelCollisionTimer.stop();
+  }
+
+  /* create AABB lines and bounding sphere of selected instance */
+  mCollisionDebugDrawTimer.start();
+  drawCollisionDebug();
+
+  /* create bounding spheres */
+  mCollidingSphereCount = 0;
+  uint32_t sphereVertexCount = 0;
+
+  switch (mRenderData.rdDrawBoundingSpheres) {
+    case collisionDebugDraw::none:
+      break;
+    case collisionDebugDraw::colliding:
+      if (!mModelInstCamData.micInstanceCollisions.empty()) {
+        createCollidingBoundingSpheres();
+        sphereVertexCount = mCollidingSphereMesh.vertices.size();
+      }
+      break;
+    case collisionDebugDraw::selected:
+      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
+      createSelectedBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+    case collisionDebugDraw::all:
+      createAllBoundingSpheres();
+      sphereVertexCount = mSphereMesh.vertices.size();
+      break;
+  }
+
+  /* behavior update */
+  mBehviorTimer.start();
+  mBehaviorManager->update(deltaTime);
+  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
+
   /* start with graphics rendering */
   std::vector<VkFence> resetFences = {
     mRenderData.rdRenderFence,
@@ -7475,56 +7554,6 @@ bool VkRenderer::draw(float deltaTime) {
     return false;
   }
 
-  /* draw coordinate lines */
-  mLineIndexCount = 0;
-  mLineMesh->vertices.clear();
-
-  /* Coordinate arrows */
-  if (mRenderData.rdApplicationMode == appMode::edit) {
-    if (mModelInstCamData.micSelectedInstance > 0) {
-      InstanceSettings instSettings = mModelInstCamData.micAssimpInstances.at(mModelInstCamData.micSelectedInstance)->getInstanceSettings();
-
-      /* draw coordiante arrows at origin of selected instance */
-      switch(mRenderData.rdInstanceEditMode) {
-        case instanceEditMode::move:
-          mCoordArrowsMesh = mCoordArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::rotate:
-          mCoordArrowsMesh = mRotationArrowsModel.getVertexData();
-          break;
-        case instanceEditMode::scale:
-          mCoordArrowsMesh = mScaleArrowsModel.getVertexData();
-          break;
-      }
-
-      mLineIndexCount += mCoordArrowsMesh.vertices.size();
-      std::for_each(mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end(),
-                    [=](auto &n) {
-                      n.color /= 2.0f;
-                      n.position = glm::quat(glm::radians(instSettings.isWorldRotation)) * n.position;
-                      n.position += instSettings.isWorldPosition;
-                    });
-      mLineMesh->vertices.insert(mLineMesh->vertices.end(),
-        mCoordArrowsMesh.vertices.begin(), mCoordArrowsMesh.vertices.end());
-    }
-  }
-
-  /* debug for interaction */
-  mInteractionTimer.start();
-  drawInteractionDebug();
-  mRenderData.rdInteractionTime += mInteractionTimer.stop();
-
-  /* level stuff */
-  if (mModelInstCamData.micLevels.size() > 1) {
-    mLevelCollisionTimer.start();
-    checkForLevelCollisions();
-    mRenderData.rdLevelCollisionTime += mLevelCollisionTimer.stop();
-  }
-
-  /* draw AABB lines and bounding sphere of selected instance */
-  mCollisionDebugDrawTimer.start();
-  drawCollisionDebug();
-
   if (!CommandBuffer::reset(mRenderData.rdLineCommandBuffer, 0)) {
     Logger::log(1, "%s error: failed to reset line drawing command buffer\n", __FUNCTION__);
     return false;
@@ -7557,30 +7586,6 @@ bool VkRenderer::draw(float deltaTime) {
     vkCmdBindVertexBuffers(mRenderData.rdLineCommandBuffer, 0, 1, &mLineVertexBuffer.buffer, &offset);
     vkCmdSetLineWidth(mRenderData.rdLineCommandBuffer, 3.0f);
     vkCmdDraw(mRenderData.rdLineCommandBuffer, static_cast<uint32_t>(mLineMesh->vertices.size()), 1, 0, 0);
-  }
-
-  /* draw bounding spheres */
-  mCollidingSphereCount = 0;
-  uint32_t sphereVertexCount = 0;
-
-  switch (mRenderData.rdDrawBoundingSpheres) {
-    case collisionDebugDraw::none:
-      break;
-    case collisionDebugDraw::colliding:
-      if (!mModelInstCamData.micInstanceCollisions.empty()) {
-        createCollidingBoundingSpheres();
-        sphereVertexCount = mCollidingSphereMesh.vertices.size();
-      }
-      break;
-    case collisionDebugDraw::selected:
-      /* no bounding sphere collision will be done with this setting, so run the computer shaders just for the selected instance */
-      createSelectedBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
-    case collisionDebugDraw::all:
-      createAllBoundingSpheres();
-      sphereVertexCount = mSphereMesh.vertices.size();
-      break;
   }
 
   /* draw colliding spheres */
@@ -7665,12 +7670,6 @@ bool VkRenderer::draw(float deltaTime) {
     return false;
   }
 
-  /* behavior update */
-  mBehviorTimer.start();
-  mBehaviorManager->update(deltaTime);
-  mRenderData.rdBehaviorTime += mBehviorTimer.stop();
-
-
   /* imGui overlay */
   mUIGenerateTimer.start();
   mUserInterface.createFrame(mRenderData);
@@ -7727,11 +7726,6 @@ bool VkRenderer::draw(float deltaTime) {
   /* submit command buffer */
   VkSubmitInfo submitInfo{};
   submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-
-  /* compute shader: contine if vertex input ready
-   * vertex shader: wait for color attachment output ready */
-  //std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdComputeSemaphore, mRenderData.rdPresentSemaphore };
-  //std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
 
   std::vector<VkSemaphore> waitSemaphores = { mRenderData.rdPresentSemaphore };
   std::vector<VkPipelineStageFlags> waitStages = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };


### PR DESCRIPTION
Collision sphere update triggered in the middle of a rendering pass, invalidating descriptor sets.